### PR TITLE
Set read bit in MCP23S17 and raise exception in TGpioLinuxPin

### DIFF
--- a/src/fpgpio.pas
+++ b/src/fpgpio.pas
@@ -460,7 +460,7 @@ var
 begin
   fd := fpOpen(aFileName, O_WRONLY);
   if fd = -1 then
-    EFOpenError.CreateFmt(SFOpenError, [aFileName]);
+    raise EFOpenError.CreateFmt(SFOpenError, [aFileName]);
   FpWrite(fd, aBuffer, aCount);
   FpClose(fd);
 end;

--- a/src/mcp23017.pas
+++ b/src/mcp23017.pas
@@ -217,7 +217,7 @@ var
 begin
   if HAEN then
   begin
-    b[0] := Address;
+    b[0] := Address or 1;
     b[1] := aRegister;
     fSPIDevice.ReadAndWrite(b[0], 2, rb[0], 3);
   end


### PR DESCRIPTION
Two things I stumbled accross:

## MCP23S17

The `r/w` byte was never set, resulting in writing zeros into the register instead of actually reading from it.
See the figure from [here](http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf).
![image](https://user-images.githubusercontent.com/24881032/54559445-62b3a680-49c0-11e9-96d8-b202eb517455.png)

## TGpioLinuxPin

When writing to a file via `TGpioLinuxPin.WriteToFile` failed, the created exception would never actually get raised and the whole operations silently fails.